### PR TITLE
remove singleton; pass _base object everywhere

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,7 +5,6 @@ requires 'Mojolicious';
 requires 'Data::Format::Pretty::JSON';
 requires 'Net::SSLeay';
 requires 'IO::Socket::SSL';
-requires 'MooseX::Singleton';
 requires 'MooseX::MetaDescription::Meta::Attribute';
 #requires 'Hash::AsObject';
 #requires 'EV';

--- a/lib/OpenSearch.pm
+++ b/lib/OpenSearch.pm
@@ -15,16 +15,14 @@ use OpenSearch::Document;
 
 our $VERSION = '0.92';
 
-has 'base' => (
+has '_base' => (
   is  => 'rw',
   isa => 'OpenSearch::Base',
-
-  #lazy => 1,
-  #default => sub { OpenSearch::Base->initialize; }
+  init_arg => undef,
 );
 
 sub BUILD( $self, $args ) {
-  $self->base( OpenSearch::Base->new(
+  $self->_base( OpenSearch::Base->new(
     user            => $args->{user},
     pass            => $args->{pass},
     hosts           => $args->{hosts},
@@ -38,23 +36,23 @@ sub BUILD( $self, $args ) {
 }
 
 sub cluster($self) {
-  return ( OpenSearch::Cluster->new );
+  return ( OpenSearch::Cluster->new(_base => $self->_base) );
 }
 
 sub remote($self) {
-  return ( OpenSearch::Remote->new );
+  return ( OpenSearch::Remote->new(_base => $self->_base) );
 }
 
 sub search($self) {
-  return ( OpenSearch::Search->new );
+  return ( OpenSearch::Search->new(_base => $self->_base) );
 }
 
 sub index($self) {
-  return ( OpenSearch::Index->new );
+  return ( OpenSearch::Index->new(_base => $self->_base) );
 }
 
 sub document($self) {
-  return ( OpenSearch::Document->new );
+  return ( OpenSearch::Document->new(_base => $self->_base) );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/OpenSearch/Base.pm
+++ b/lib/OpenSearch/Base.pm
@@ -2,7 +2,6 @@ package OpenSearch::Base;
 use strict;
 use warnings;
 use Moose;
-use MooseX::Singleton;
 use Mojo::UserAgent;
 use Mojo::URL;
 use Data::Dumper;

--- a/lib/OpenSearch/Cluster.pm
+++ b/lib/OpenSearch/Cluster.pm
@@ -18,49 +18,55 @@ use OpenSearch::Cluster::SetRoutingAwareness;
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
+has '_base' => (
+  is  => 'rw',
+  isa => 'OpenSearch::Base',
+  required => 1,
+);
+
 sub get_settings( $self, @params ) {
-  return ( OpenSearch::Cluster::GetSettings->new(@params)->execute );
+  return ( OpenSearch::Cluster::GetSettings->new(@params, _base => $self->_base)->execute );
 }
 
 sub update_settings( $self, @params ) {
-  return ( OpenSearch::Cluster::UpdateSettings->new(@params)->execute );
+  return ( OpenSearch::Cluster::UpdateSettings->new(@params, _base => $self->_base)->execute );
 }
 
 sub health( $self, @params ) {
-  return ( OpenSearch::Cluster::Health->new(@params)->execute );
+  return ( OpenSearch::Cluster::Health->new(@params, _base => $self->_base)->execute );
 }
 
 sub stats( $self, @params ) {
-  return ( OpenSearch::Cluster::Stats->new(@params)->execute );
+  return ( OpenSearch::Cluster::Stats->new(@params, _base => $self->_base)->execute );
 }
 
 sub allocation_explain( $self, @params ) {
-  return ( OpenSearch::Cluster::AllocationExplain->new(@params)->execute );
+  return ( OpenSearch::Cluster::AllocationExplain->new(@params, _base => $self->_base)->execute );
 }
 
 # TODO: Look more into Decommission Endpoints...
 sub get_decommission_awareness( $self, @params ) {
-  return ( OpenSearch::Cluster::GetDecommissionAwareness->new(@params)->execute );
+  return ( OpenSearch::Cluster::GetDecommissionAwareness->new(@params, _base => $self->_base)->execute );
 }
 
 sub set_decommission_awareness( $self, @params ) {
-  return ( OpenSearch::Cluster::SetDecommissionAwareness->new(@params)->execute );
+  return ( OpenSearch::Cluster::SetDecommissionAwareness->new(@params, _base => $self->_base)->execute );
 }
 
 sub del_decommission_awareness( $self, @params ) {
-  return ( OpenSearch::Cluster::DelDecommissionAwareness->new(@params)->execute );
+  return ( OpenSearch::Cluster::DelDecommissionAwareness->new(@params, _base => $self->_base)->execute );
 }
 
 sub get_routing_awareness( $self, @params ) {
-  return ( OpenSearch::Cluster::GetRoutingAwareness->new(@params)->execute );
+  return ( OpenSearch::Cluster::GetRoutingAwareness->new(@params, _base => $self->_base)->execute );
 }
 
 sub del_routing_awareness( $self, @params ) {
-  return ( OpenSearch::Cluster::DelRoutingAwareness->new(@params)->execute );
+  return ( OpenSearch::Cluster::DelRoutingAwareness->new(@params, _base => $self->_base)->execute );
 }
 
 sub set_routing_awareness( $self, @params ) {
-  return ( OpenSearch::Cluster::SetRoutingAwareness->new(@params)->execute );
+  return ( OpenSearch::Cluster::SetRoutingAwareness->new(@params, _base => $self->_base)->execute );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/OpenSearch/Cluster/AllocationExplain.pm
+++ b/lib/OpenSearch/Cluster/AllocationExplain.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Cluster::AllocationExplain';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Cluster/DelDecommissionAwareness.pm
+++ b/lib/OpenSearch/Cluster/DelDecommissionAwareness.pm
@@ -10,9 +10,7 @@ no warnings qw(experimental::signatures);
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Cluster/DelRoutingAwareness.pm
+++ b/lib/OpenSearch/Cluster/DelRoutingAwareness.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Cluster::DelRoutingAwareness';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Cluster/GetDecommissionAwareness.pm
+++ b/lib/OpenSearch/Cluster/GetDecommissionAwareness.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Cluster::GetDecommissionAwareness';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Cluster/GetRoutingAwareness.pm
+++ b/lib/OpenSearch/Cluster/GetRoutingAwareness.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Cluster::GetRoutingAwareness';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Cluster/GetSettings.pm
+++ b/lib/OpenSearch/Cluster/GetSettings.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Cluster::GetSettings';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Cluster/Health.pm
+++ b/lib/OpenSearch/Cluster/Health.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Cluster::Health';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Cluster/SetDecommissionAwareness.pm
+++ b/lib/OpenSearch/Cluster/SetDecommissionAwareness.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Cluster::SetDecommissionAwareness';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Cluster/SetRoutingAwareness.pm
+++ b/lib/OpenSearch/Cluster/SetRoutingAwareness.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Cluster::SetRoutingAwareness';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Cluster/Stats.pm
+++ b/lib/OpenSearch/Cluster/Stats.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Cluster::Stats';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Cluster/UpdateSettings.pm
+++ b/lib/OpenSearch/Cluster/UpdateSettings.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Cluster::UpdateSettings';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Document.pm
+++ b/lib/OpenSearch/Document.pm
@@ -9,16 +9,22 @@ use OpenSearch::Document::Get;
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
+has '_base' => (
+  is  => 'rw',
+  isa => 'OpenSearch::Base',
+  required => 1,
+);
+
 sub index( $self, @params ) {
-  return ( OpenSearch::Document::Index->new(@params)->execute );
+  return ( OpenSearch::Document::Index->new(@params, _base => $self->_base)->execute );
 }
 
 sub bulk( $self, @params ) {
-  return ( OpenSearch::Document::Bulk->new(@params)->execute );
+  return ( OpenSearch::Document::Bulk->new(@params, _base => $self->_base)->execute );
 }
 
 sub get( $self, @params ) {
-  return ( OpenSearch::Document::Get->new(@params)->execute );
+  return ( OpenSearch::Document::Get->new(@params, _base => $self->_base)->execute );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/OpenSearch/Document/Bulk.pm
+++ b/lib/OpenSearch/Document/Bulk.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Document::Bulk';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Document/Get.pm
+++ b/lib/OpenSearch/Document/Get.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Document::Get';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Document/Index.pm
+++ b/lib/OpenSearch/Document/Index.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Document::Index';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Helper.pm
+++ b/lib/OpenSearch/Helper.pm
@@ -36,7 +36,7 @@ sub _generate_params( $self, $instance ) {
     # TODO: This might conflice with attributes starting with _.
     #       ie. _source, _source_includes, _source_excludes
     #       Since these are optional we dont care about them for now.
-    next if ( $param =~ m/^_base/ );
+    next if ( $param eq "_base" );
     my $desc = $instance->meta->{attributes}->{$param}->description;
     my $enc  = $desc->{encode_func} // 'as_is';
     my $req  = $desc->{required};

--- a/lib/OpenSearch/Index.pm
+++ b/lib/OpenSearch/Index.pm
@@ -28,92 +28,98 @@ use OpenSearch::Index::UpdateSettings;
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
+has '_base' => (
+  is  => 'rw',
+  isa => 'OpenSearch::Base',
+  required => 1,
+);
+
 sub create( $self, @params ) {
-  return ( OpenSearch::Index::Create->new(@params)->execute );
+  return ( OpenSearch::Index::Create->new(@params, _base => $self->_base)->execute );
 }
 
 sub delete( $self, @params ) {
-  return ( OpenSearch::Index::Delete->new(@params)->execute );
+  return ( OpenSearch::Index::Delete->new(@params, _base => $self->_base)->execute );
 }
 
 sub set_aliases( $self, @params ) {
-  return ( OpenSearch::Index::SetAliases->new(@params)->execute );
+  return ( OpenSearch::Index::SetAliases->new(@params, _base => $self->_base)->execute );
 }
 
 sub get_aliases( $self, @params ) {
-  return ( OpenSearch::Index::GetAliases->new(@params)->execute );
+  return ( OpenSearch::Index::GetAliases->new(@params, _base => $self->_base)->execute );
 }
 
 sub clear_cache( $self, @params ) {
-  return ( OpenSearch::Index::ClearCache->new(@params)->execute );
+  return ( OpenSearch::Index::ClearCache->new(@params, _base => $self->_base)->execute );
 }
 
 sub clone( $self, @params ) {
-  return ( OpenSearch::Index::Clone->new(@params)->execute );
+  return ( OpenSearch::Index::Clone->new(@params, _base => $self->_base)->execute );
 }
 
 sub close( $self, @params ) {
-  return ( OpenSearch::Index::Close->new(@params)->execute );
+  return ( OpenSearch::Index::Close->new(@params, _base => $self->_base)->execute );
 }
 
 sub set_mappings( $self, @params ) {
-  return ( OpenSearch::Index::SetMappings->new(@params)->execute );
+  return ( OpenSearch::Index::SetMappings->new(@params, _base => $self->_base)->execute );
 }
 
 sub get_mappings( $self, @params ) {
-  return ( OpenSearch::Index::GetMappings->new(@params)->execute );
+  return ( OpenSearch::Index::GetMappings->new(@params, _base => $self->_base)->execute );
 }
 
 sub get_dangling( $self, @params ) {
-  return ( OpenSearch::Index::GetDangling->new(@params)->execute );
+  return ( OpenSearch::Index::GetDangling->new(@params, _base => $self->_base)->execute );
 }
 
 sub import_dangling( $self, @params ) {
-  return ( OpenSearch::Index::ImportDangling->new(@params)->execute );
+  return ( OpenSearch::Index::ImportDangling->new(@params, _base => $self->_base)->execute );
 }
 
 sub delete_dangling( $self, @params ) {
-  return ( OpenSearch::Index::DeleteDangling->new(@params)->execute );
+  return ( OpenSearch::Index::DeleteDangling->new(@params, _base => $self->_base)->execute );
 }
 
 sub get( $self, @params ) {
-  return ( OpenSearch::Index::Get->new(@params)->execute );
+  return ( OpenSearch::Index::Get->new(@params, _base => $self->_base)->execute );
 }
 
 sub exists( $self, @params ) {
-  return ( OpenSearch::Index::Exists->new(@params)->execute );
+  return ( OpenSearch::Index::Exists->new(@params, _base => $self->_base)->execute );
 }
 
 sub force_merge( $self, @params ) {
-  return ( OpenSearch::Index::ForceMerge->new(@params)->execute );
+  return ( OpenSearch::Index::ForceMerge->new(@params, _base => $self->_base)->execute );
 }
 
 sub open( $self, @params ) {
-  return ( OpenSearch::Index::Open->new(@params)->execute );
+  return ( OpenSearch::Index::Open->new(@params, _base => $self->_base)->execute );
 }
 
 sub refresh( $self, @params ) {
-  return ( OpenSearch::Index::Refresh->new(@params)->execute );
+  return ( OpenSearch::Index::Refresh->new(@params, _base => $self->_base)->execute );
 }
 
 sub shrink( $self, @params ) {
-  return ( OpenSearch::Index::Shrink->new(@params)->execute );
+  return ( OpenSearch::Index::Shrink->new(@params, _base => $self->_base)->execute );
 }
 
 sub split( $self, @params ) {
-  return ( OpenSearch::Index::Split->new(@params)->execute );
+  return ( OpenSearch::Index::Split->new(@params, _base => $self->_base)->execute );
 }
 
 sub stats( $self, @params ) {
-  return ( OpenSearch::Index::Stats->new(@params)->execute );
+  return ( OpenSearch::Index::Stats->new(@params, _base => $self->_base)->execute );
 }
 
 sub get_settings( $self, @params ) {
-  return ( OpenSearch::Index::GetSettings->new(@params)->execute );
+  return ( OpenSearch::Index::GetSettings->new(@params, _base => $self->_base)->execute );
 }
 
 sub update_settings( $self, @params ) {
-  return ( OpenSearch::Index::UpdateSettings->new(@params)->execute );
+  return ( OpenSearch::Index::UpdateSettings->new(@params, _base => $self->_base)->execute );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/OpenSearch/Index/ClearCache.pm
+++ b/lib/OpenSearch/Index/ClearCache.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::ClearCache';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Clone.pm
+++ b/lib/OpenSearch/Index/Clone.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Clone';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Close.pm
+++ b/lib/OpenSearch/Index/Close.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Close';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Create.pm
+++ b/lib/OpenSearch/Index/Create.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Create';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Delete.pm
+++ b/lib/OpenSearch/Index/Delete.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Delete';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/DeleteDangling.pm
+++ b/lib/OpenSearch/Index/DeleteDangling.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::DeleteDangling';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Exists.pm
+++ b/lib/OpenSearch/Index/Exists.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Exists';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/ForceMerge.pm
+++ b/lib/OpenSearch/Index/ForceMerge.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::ForceMerge';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Get.pm
+++ b/lib/OpenSearch/Index/Get.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Get';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/GetAliases.pm
+++ b/lib/OpenSearch/Index/GetAliases.pm
@@ -10,9 +10,7 @@ no warnings qw(experimental::signatures);
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/GetDangling.pm
+++ b/lib/OpenSearch/Index/GetDangling.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::GetDangling';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/GetMappings.pm
+++ b/lib/OpenSearch/Index/GetMappings.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::GetMappings';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/GetSettings.pm
+++ b/lib/OpenSearch/Index/GetSettings.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::GetSettings';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/ImportDangling.pm
+++ b/lib/OpenSearch/Index/ImportDangling.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::ImportDangling';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Open.pm
+++ b/lib/OpenSearch/Index/Open.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Open';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Refresh.pm
+++ b/lib/OpenSearch/Index/Refresh.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Refresh';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/SetAliases.pm
+++ b/lib/OpenSearch/Index/SetAliases.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::SetAliases';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/SetMappings.pm
+++ b/lib/OpenSearch/Index/SetMappings.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::SetMappings';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Shrink.pm
+++ b/lib/OpenSearch/Index/Shrink.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Shrink';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Split.pm
+++ b/lib/OpenSearch/Index/Split.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Split';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/Stats.pm
+++ b/lib/OpenSearch/Index/Stats.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::Stats';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Index/UpdateSettings.pm
+++ b/lib/OpenSearch/Index/UpdateSettings.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Index::UpdateSettings';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Remote.pm
+++ b/lib/OpenSearch/Remote.pm
@@ -7,8 +7,14 @@ use OpenSearch::Remote::Info;
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
+has '_base' => (
+  is  => 'rw',
+  isa => 'OpenSearch::Base',
+  required => 1,
+);
+
 sub info( $self, @params ) {
-  return ( OpenSearch::Remote::Info->new(@params)->execute );
+  return ( OpenSearch::Remote::Info->new(@params, _base => $self->_base)->execute );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/OpenSearch/Remote/Info.pm
+++ b/lib/OpenSearch/Remote/Info.pm
@@ -8,9 +8,7 @@ no warnings qw(experimental::signatures);
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Search.pm
+++ b/lib/OpenSearch/Search.pm
@@ -8,12 +8,18 @@ use OpenSearch::Search::Count;
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
+has '_base' => (
+  is  => 'rw',
+  isa => 'OpenSearch::Base',
+  required => 1,
+);
+
 sub search( $self, @params ) {
-  return ( OpenSearch::Search::Search->new(@params)->execute );
+  return ( OpenSearch::Search::Search->new(@params, _base => $self->_base)->execute );
 }
 
 sub count( $self, @params ) {
-  return ( OpenSearch::Search::Count->new(@params)->execute );
+  return ( OpenSearch::Search::Count->new(@params, _base => $self->_base)->execute );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/OpenSearch/Search/Count.pm
+++ b/lib/OpenSearch/Search/Count.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Search::Count';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {

--- a/lib/OpenSearch/Search/Search.pm
+++ b/lib/OpenSearch/Search/Search.pm
@@ -10,9 +10,7 @@ with 'OpenSearch::Parameters::Search::Search';
 has '_base' => (
   is       => 'rw',
   isa      => 'OpenSearch::Base',
-  required => 0,
-  lazy     => 1,
-  default  => sub { OpenSearch::Base->instance; }
+  required => 1,
 );
 
 sub execute($self) {


### PR DESCRIPTION
* removed singleton
* passes base instance everywhere needed
* renamed attribute to `_base` to make local usage more clear, and set `init_arg` to `undef` to avoid outside interference