### PR TITLE
replace Moose by Moo and Type::Tiny

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,12 +5,15 @@ requires 'Mojolicious';
 requires 'Data::Format::Pretty::JSON';
 requires 'Net::SSLeay';
 requires 'IO::Socket::SSL';
-requires 'MooseX::MetaDescription::Meta::Attribute';
 #requires 'Hash::AsObject';
 #requires 'EV';
+requires 'Moo';
+requires 'Type::Tiny';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';
     requires 'Test::Pod::Coverage';
 };
 
+recommends 'Type::Tiny::XS'; # improve performance Type::Tiny even more
+recommends 'Class::XSAccessor'; # improve performance Moo accessors

--- a/lib/OpenSearch.pm
+++ b/lib/OpenSearch.pm
@@ -1,7 +1,8 @@
 package OpenSearch;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 use Data::Dumper;
@@ -17,7 +18,7 @@ our $VERSION = '0.92';
 
 has '_base' => (
   is  => 'rw',
-  isa => 'OpenSearch::Base',
+  isa => InstanceOf['OpenSearch::Base'],
   init_arg => undef,
 );
 
@@ -55,7 +56,7 @@ sub document($self) {
   return ( OpenSearch::Document->new(_base => $self->_base) );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;
 
 __END__

--- a/lib/OpenSearch/Base.pm
+++ b/lib/OpenSearch/Base.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Base;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(Str Bool Int ArrayRef InstanceOf);
 use Mojo::UserAgent;
 use Mojo::URL;
 use Data::Dumper;
@@ -11,31 +12,29 @@ no warnings qw(experimental::signatures);
 
 with 'OpenSearch::Helper';
 
-# This is a singleton class. We only want one instance of this class.
-
-has 'user'            => ( is => 'rw', isa => 'Str', required => 0 );   # Not really required since we can use Cert-Auth
-has 'pass'            => ( is => 'rw', isa => 'Str', required => 0 );   # Not really required since we can use Cert-Auth
-has 'ca_cert'         => ( is => 'rw', isa => 'Str', required => 0 );   # Dunno if that will work right now...
-has 'client_cert'     => ( is => 'rw', isa => 'Str', required => 0 );   # Dunno if that will work right now...
-has 'client_key'      => ( is => 'rw', isa => 'Str', required => 0 );   # Dunno if that will work right now...
-has 'hosts'           => ( is => 'rw', isa => 'ArrayRef[Str]', required => 1 );
-has 'secure'          => ( is => 'rw', isa => 'Str',           required => 1 );
-has 'allow_insecure'  => ( is => 'rw', isa => 'Str',           required => 0, default => sub { 0; } );
-has 'async'           => ( is => 'rw', isa => 'Bool',          required => 0, default => sub { 0; } );
-has 'max_connections' => ( is => 'rw', isa => 'Int',           required => 0, default => sub { 5; } );
+has 'user'            => ( is => 'rw', isa => Str, required => 0 );   # Not really required since we can use Cert-Auth
+has 'pass'            => ( is => 'rw', isa => Str, required => 0 );   # Not really required since we can use Cert-Auth
+has 'ca_cert'         => ( is => 'rw', isa => Str, required => 0 );   # Dunno if that will work right now...
+has 'client_cert'     => ( is => 'rw', isa => Str, required => 0 );   # Dunno if that will work right now...
+has 'client_key'      => ( is => 'rw', isa => Str, required => 0 );   # Dunno if that will work right now...
+has 'hosts'           => ( is => 'rw', isa => ArrayRef[Str], required => 1 );
+has 'secure'          => ( is => 'rw', isa => Str,           required => 1 );
+has 'allow_insecure'  => ( is => 'rw', isa => Str,           required => 0, default => sub { 0; } );
+has 'async'           => ( is => 'rw', isa => Bool,          required => 0, default => sub { 0; } );
+has 'max_connections' => ( is => 'rw', isa => Int,           required => 0, default => sub { 5; } );
 
 # Clean attributes after each request. This is a bit of a hack. We should probably use a
 # new instance of the class for each request.
-has 'clear_attrs' => ( is => 'rw', isa => 'Bool', required => 0, default => sub { 0; } );
+has 'clear_attrs' => ( is => 'rw', isa => Bool, required => 0, default => sub { 0; } );
 
 # If one host is down, we put it here. Dont know yet how to test if a host is back up again
-has 'disabled_hosts' => ( is => 'rw', isa => 'ArrayRef[Str]', default => sub { []; } );
+has 'disabled_hosts' => ( is => 'rw', isa => ArrayRef[Str], default => sub { []; } );
 
 # We pre-create a number of Mojo::UserAgent Objects (dont know if that works)
-has 'pool_count' => ( is => 'rw', isa => 'Int', default => sub { 1; } );
+has 'pool_count' => ( is => 'rw', isa => Int, default => sub { 1; } );
 
 # Without this the ua will get out of scope to early and result in a Premature connection close...
-has 'ua_pool' => ( is => 'rw', isa => 'ArrayRef[Mojo::UserAgent]', lazy => 1, default => sub { []; } );
+has 'ua_pool' => ( is => 'rw', isa => ArrayRef[InstanceOf['Mojo::UserAgent']], lazy => 1, default => sub { []; } );
 
 sub BUILD( $self, @rest ) {
 
@@ -129,5 +128,5 @@ sub response( $self, $tx ) {
   return ( OpenSearch::Response->new( _response => $tx->result ) );
 }
 
-#__PACKAGE__->meta->make_immutable;
+#
 1;

--- a/lib/OpenSearch/Cluster.pm
+++ b/lib/OpenSearch/Cluster.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use Data::Dumper;
 
 use OpenSearch::Cluster::GetSettings;
@@ -20,7 +21,7 @@ no warnings qw(experimental::signatures);
 
 has '_base' => (
   is  => 'rw',
-  isa => 'OpenSearch::Base',
+  isa => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -69,7 +70,7 @@ sub set_routing_awareness( $self, @params ) {
   return ( OpenSearch::Cluster::SetRoutingAwareness->new(@params, _base => $self->_base)->execute );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;
 
 __END__

--- a/lib/OpenSearch/Cluster/AllocationExplain.pm
+++ b/lib/OpenSearch/Cluster/AllocationExplain.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::AllocationExplain;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Cluster::AllocationExplain';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,4 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ '_cluster', 'allocation', 'explain' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/OpenSearch/Cluster/DelDecommissionAwareness.pm
+++ b/lib/OpenSearch/Cluster/DelDecommissionAwareness.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::DelDecommissionAwareness;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ no warnings qw(experimental::signatures);
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_delete( $self, [ '_cluster', 'decommission', 'awareness' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Cluster/DelRoutingAwareness.pm
+++ b/lib/OpenSearch/Cluster/DelRoutingAwareness.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::DelRoutingAwareness;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Cluster::DelRoutingAwareness';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_delete( $self, [ '_cluster', 'routing', 'awareness', $self->attribute, 'weights' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Cluster/GetDecommissionAwareness.pm
+++ b/lib/OpenSearch/Cluster/GetDecommissionAwareness.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::GetDecommissionAwareness;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Cluster::GetDecommissionAwareness';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ '_cluster', 'decommission', 'awareness', $self->attribute, '_status' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Cluster/GetRoutingAwareness.pm
+++ b/lib/OpenSearch/Cluster/GetRoutingAwareness.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::GetRoutingAwareness;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Cluster::GetRoutingAwareness';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ '_cluster', 'routing', 'awareness', $self->attribute, 'weights' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Cluster/GetSettings.pm
+++ b/lib/OpenSearch/Cluster/GetSettings.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::GetSettings;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Cluster::GetSettings';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ '_cluster', 'settings' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Cluster/Health.pm
+++ b/lib/OpenSearch/Cluster/Health.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::Health;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Cluster::Health';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ '_cluster', 'health', ( $self->index // () ) ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Cluster/SetDecommissionAwareness.pm
+++ b/lib/OpenSearch/Cluster/SetDecommissionAwareness.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::SetDecommissionAwareness;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Cluster::SetDecommissionAwareness';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_put( $self, [ '_cluster', 'decommission', 'awareness', $self->attribute, $self->value ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Cluster/SetRoutingAwareness.pm
+++ b/lib/OpenSearch/Cluster/SetRoutingAwareness.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::SetRoutingAwareness;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Cluster::SetRoutingAwareness';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_put( $self, [ '_cluster', 'routing', 'awareness', $self->attribute, 'weights' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Cluster/Stats.pm
+++ b/lib/OpenSearch/Cluster/Stats.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::Stats;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Cluster::Stats';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ '_cluster', 'stats', ( $self->nodes ? ( 'nodes', $self->nodes ) : () ) ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Cluster/UpdateSettings.pm
+++ b/lib/OpenSearch/Cluster/UpdateSettings.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Cluster::UpdateSettings;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Cluster::UpdateSettings';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_put( $self, [ '_cluster', 'settings' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Document.pm
+++ b/lib/OpenSearch/Document.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Document;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use Data::Dumper;
 use OpenSearch::Document::Index;
 use OpenSearch::Document::Bulk;
@@ -11,7 +12,7 @@ no warnings qw(experimental::signatures);
 
 has '_base' => (
   is  => 'rw',
-  isa => 'OpenSearch::Base',
+  isa => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -27,5 +28,5 @@ sub get( $self, @params ) {
   return ( OpenSearch::Document::Get->new(@params, _base => $self->_base)->execute );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Document/Bulk.pm
+++ b/lib/OpenSearch/Document/Bulk.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Document::Bulk;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Document::Bulk';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, [ ( $self->index // () ), '_bulk' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Document/Get.pm
+++ b/lib/OpenSearch/Document/Get.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Document::Get;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Document::Get';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ $self->index, '_doc', ( $self->id ? $self->id : () ) ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Document/Get.pm
+++ b/lib/OpenSearch/Document/Get.pm
@@ -15,7 +15,7 @@ has '_base' => (
 );
 
 sub execute($self) {
-  my $res = $self->_base->_get( $self, [ $self->index, '_doc', ( $self->id ? $self->id : () ) ] );
+  my $res = $self->_base->_get( $self, [ $self->index, '_doc', $self->id ] );
 }
 
 

--- a/lib/OpenSearch/Document/Index.pm
+++ b/lib/OpenSearch/Document/Index.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Document::Index;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Document::Index';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -19,5 +20,5 @@ sub execute($self) {
     [ $self->index, ( $self->create ? '_create' : '_doc' ), ( $self->id ? $self->id : () ) ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Filter/Nodes.pm
+++ b/lib/OpenSearch/Filter/Nodes.pm
@@ -1,11 +1,12 @@
 package OpenSearch::Filter::Nodes;
 use strict;
 use warnings;
-use Moose::Util::TypeConstraints;
-use Moose;
+use Types::Standard qw(Str Enum);
+use Moo;
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
+=head1 TODO
 subtype 'node_id',   as 'Str', where { $_ =~ /^[a-zA-Z0-9_]+$/ };
 subtype 'node_name', as 'Str', where { $_ =~ /^[a-zA-Z0-9_\-\.]+$/ };    # Dont actually know how it may look like?
 subtype 'node_ip', as 'Str',
@@ -69,6 +70,5 @@ sub to_string($self) {
   }
 
 }
-
-__PACKAGE__->meta->make_immutable;
+=cut
 1;

--- a/lib/OpenSearch/Filter/Source.pm
+++ b/lib/OpenSearch/Filter/Source.pm
@@ -1,14 +1,15 @@
 package OpenSearch::Filter::Source;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(Bool ArrayRef);
 use Data::Dumper;
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
-has 'includes' => ( is => 'rw', isa => 'ArrayRef', default => sub { []; } );
-has 'excludes' => ( is => 'rw', isa => 'ArrayRef', default => sub { []; } );
-has 'source'   => ( is => 'rw', isa => 'Bool',     default => sub { 1; } );
+has 'includes' => ( is => 'rw', isa => ArrayRef, default => sub { []; } );
+has 'excludes' => ( is => 'rw', isa => ArrayRef, default => sub { []; } );
+has 'source'   => ( is => 'rw', isa => Bool,     default => sub { 1; } );
 
 around BUILDARGS => sub {
   my $orig  = shift;
@@ -44,5 +45,4 @@ sub to_hash($self) {
   return ( { includes => $self->includes, excludes => $self->excludes } );
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/OpenSearch/Helper.pm
+++ b/lib/OpenSearch/Helper.pm
@@ -1,10 +1,9 @@
 package OpenSearch::Helper;
 use strict;
 use warnings;
-use Moose::Role;
+use Moo::Role;
 use JSON::XS;
 use Data::Dumper;
-use Carp qw/croak/;
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -28,18 +27,13 @@ my $functions = {
 sub _generate_params( $self, $instance ) {
   my $parsed = { url => {}, body => {} };
   my $forced = undef;
+  my $api_spec = $instance->api_spec;
 
-  foreach my $param ( keys( %{ $instance->meta->{attributes} } ) ) {
+  foreach my $param ( keys( %{ $api_spec } ) ) {
     my $value = $instance->$param;
 
-    # Skip "private" attributes starting with _
-    # TODO: This might conflice with attributes starting with _.
-    #       ie. _source, _source_includes, _source_excludes
-    #       Since these are optional we dont care about them for now.
-    next if ( $param eq "_base" );
-    my $desc = $instance->meta->{attributes}->{$param}->description;
+    my $desc = $api_spec->{$param};
     my $enc  = $desc->{encode_func} // 'as_is';
-    my $req  = $desc->{required};
     my $type = $desc->{type};
     my $fb   = $desc->{forced_body};
 
@@ -49,15 +43,6 @@ sub _generate_params( $self, $instance ) {
     # If forced_body is set by any attribute, we will only use this body param
     if ( $value && $fb ) {
       $forced = 1;
-    }
-
-    if ($req) {
-      my $caller = ( caller(4) )[3];
-
-      croak( "Parameter: '" . $param . "' is required for " . $caller . ":\n\n" )
-        if ( !defined($value)
-        || ( ref($value) eq 'ARRAY' && !scalar( @{$value} ) )
-        || ( ref($value) eq 'HASH'  && !keys( %{$value} ) ) );
     }
 
     if ( $type ne 'path' ) {

--- a/lib/OpenSearch/Index.pm
+++ b/lib/OpenSearch/Index.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use Data::Dumper;
 use OpenSearch::Index::SetAliases;
 use OpenSearch::Index::GetAliases;
@@ -30,7 +31,7 @@ no warnings qw(experimental::signatures);
 
 has '_base' => (
   is  => 'rw',
-  isa => 'OpenSearch::Base',
+  isa => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -122,7 +123,7 @@ sub update_settings( $self, @params ) {
   return ( OpenSearch::Index::UpdateSettings->new(@params, _base => $self->_base)->execute );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;
 
 __END__

--- a/lib/OpenSearch/Index/ClearCache.pm
+++ b/lib/OpenSearch/Index/ClearCache.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::ClearCache;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::ClearCache';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, [ ( $self->index // () ), '_cache', 'clear' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Clone.pm
+++ b/lib/OpenSearch/Index/Clone.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Clone;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Clone';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, [ $self->index, '_clone', $self->target ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Close.pm
+++ b/lib/OpenSearch/Index/Close.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Close;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Close';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, [ $self->index, '_close' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Create.pm
+++ b/lib/OpenSearch/Index/Create.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Create;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Create';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_put( $self, [ $self->index ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Delete.pm
+++ b/lib/OpenSearch/Index/Delete.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Delete;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Delete';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_delete( $self, [ $self->index ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/DeleteDangling.pm
+++ b/lib/OpenSearch/Index/DeleteDangling.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::DeleteDangling;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::DeleteDangling';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_delete( $self, [ '_dangling', $self->index_uuid ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Exists.pm
+++ b/lib/OpenSearch/Index/Exists.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Exists;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Exists';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_head( $self, [ $self->index ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/ForceMerge.pm
+++ b/lib/OpenSearch/Index/ForceMerge.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::ForceMerge;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::ForceMerge';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, [ ( $self->index // () ), '_forcemerge' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Get.pm
+++ b/lib/OpenSearch/Index/Get.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Get;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Get';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ $self->index ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/GetAliases.pm
+++ b/lib/OpenSearch/Index/GetAliases.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::GetAliases;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ no warnings qw(experimental::signatures);
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,9 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, ['_aliases'] );
 }
 
-__PACKAGE__->meta->make_immutable;
+# TODO: remove this when parameter package is done
+sub api_spec {
+  +{};
+}
+
 1;

--- a/lib/OpenSearch/Index/GetDangling.pm
+++ b/lib/OpenSearch/Index/GetDangling.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::GetDangling;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::GetDangling';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ '_dangling', ( $self->index_uuid // () ) ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/GetMappings.pm
+++ b/lib/OpenSearch/Index/GetMappings.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::GetMappings;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::GetMappings';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -18,5 +19,5 @@ sub execute($self) {
     $self->_base->_get( $self, [ $self->index, '_mapping', ( $self->field ? ( 'field', $self->field ) : () ) ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/GetSettings.pm
+++ b/lib/OpenSearch/Index/GetSettings.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::GetSettings;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::GetSettings';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ ( $self->index // () ), '_settings', ( $self->setting // () ) ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/ImportDangling.pm
+++ b/lib/OpenSearch/Index/ImportDangling.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::ImportDangling;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::ImportDangling';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, [ '_dangling', $self->index_uuid ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Open.pm
+++ b/lib/OpenSearch/Index/Open.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Open;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Open';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, [ $self->index, '_open' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Refresh.pm
+++ b/lib/OpenSearch/Index/Refresh.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Refresh;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Refresh';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, [ ( $self->index // () ), '_refresh' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/SetAliases.pm
+++ b/lib/OpenSearch/Index/SetAliases.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::SetAliases;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::SetAliases';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, ['_aliases'] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/SetMappings.pm
+++ b/lib/OpenSearch/Index/SetMappings.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::SetMappings;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::SetMappings';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_put( $self, [ $self->index, '_mapping' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Shrink.pm
+++ b/lib/OpenSearch/Index/Shrink.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Shrink;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Shrink';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, [ $self->index, '_shrink', $self->target ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Split.pm
+++ b/lib/OpenSearch/Index/Split.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Split;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Split';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_post( $self, [ $self->index, '_split', $self->target ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/Stats.pm
+++ b/lib/OpenSearch/Index/Stats.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::Stats;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::Stats';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ ( $self->index // () ), '_stats', ( $self->metric // () ) ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Index/UpdateSettings.pm
+++ b/lib/OpenSearch/Index/UpdateSettings.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Index::UpdateSettings;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Index::UpdateSettings';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_put( $self, [ $self->index, '_settings' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Parameters.pm
+++ b/lib/OpenSearch/Parameters.pm
@@ -1,0 +1,8 @@
+package OpenSearch::Parameters;
+use strict;
+use warnings;
+use Moo::Role;
+
+requires 'api_spec';
+
+1;

--- a/lib/OpenSearch/Parameters/Cluster/AllocationExplain.pm
+++ b/lib/OpenSearch/Parameters/Cluster/AllocationExplain.pm
@@ -1,70 +1,40 @@
 package OpenSearch::Parameters::Cluster::AllocationExplain;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'current_node' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'primary' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'shard' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'include_disk_info' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'include_yes_decisions' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 around [qw/current_node index primary shard include_disk_info include_yes_decisions/] => sub {
@@ -77,5 +47,34 @@ around [qw/current_node index primary shard include_disk_info include_yes_decisi
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    current_node => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    index => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    primary => {
+      encode_func => 'encode_bool',
+      type        => 'body',
+    },
+    shard => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    include_disk_info => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    include_yes_decisions => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Cluster/DelRoutingAwareness.pm
+++ b/lib/OpenSearch/Parameters/Cluster/DelRoutingAwareness.pm
@@ -1,16 +1,15 @@
 package OpenSearch::Parameters::Cluster::DelRoutingAwareness;
-use Moose::Role;
-use Moose::Util::TypeConstraints;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'attribute' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/attribute/] => sub {
@@ -23,5 +22,14 @@ around [qw/attribute/] => sub {
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    attribute => {
+      encode_func => 'as_is',
+      type        => 'path',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Cluster/GetDecommissionAwareness.pm
+++ b/lib/OpenSearch/Parameters/Cluster/GetDecommissionAwareness.pm
@@ -1,16 +1,15 @@
 package OpenSearch::Parameters::Cluster::GetDecommissionAwareness;
-use Moose::Role;
-use Moose::Util::TypeConstraints;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'attribute' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/attribute/] => sub {
@@ -23,5 +22,14 @@ around [qw/attribute/] => sub {
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    attribute => {
+      encode_func => 'as_is',
+      type        => 'path',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Cluster/GetRoutingAwareness.pm
+++ b/lib/OpenSearch/Parameters/Cluster/GetRoutingAwareness.pm
@@ -1,16 +1,15 @@
 package OpenSearch::Parameters::Cluster::GetRoutingAwareness;
-use Moose::Role;
-use Moose::Util::TypeConstraints;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'attribute' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/attribute/] => sub {
@@ -23,5 +22,14 @@ around [qw/attribute/] => sub {
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    attribute => {
+      encode_func => 'as_is',
+      type        => 'path',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Cluster/GetSettings.pm
+++ b/lib/OpenSearch/Parameters/Cluster/GetSettings.pm
@@ -1,48 +1,30 @@
 package OpenSearch::Parameters::Cluster::GetSettings;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'flat_settings' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'include_defaults' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/flat_settings include_defaults cluster_manager_timeout timeout/] => sub {
@@ -55,5 +37,26 @@ around [qw/flat_settings include_defaults cluster_manager_timeout timeout/] => s
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    flat_settings => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    include_defaults => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Cluster/Health.pm
+++ b/lib/OpenSearch/Parameters/Cluster/Health.pm
@@ -1,164 +1,80 @@
 package OpenSearch::Parameters::Cluster::Health;
-use Moose::Role;
-use Moose::Util::TypeConstraints;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int HashRef Enum);
+use Moo::Role;
 
-enum 'HealthExpandWildcards' => [qw/all open closed hidden none/];
-enum 'HealthLevel'           => [qw/cluster indices shards awareness_attributes/];
-enum 'HealthWaitForEvents'   => [qw/immediate urgent high normal low languid/];
-enum 'HealthWaitForStatus'   => [qw/green yellow red/];
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'HealthExpandWildcards',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Enum[qw(all open closed hidden none)],
 );
 
 has 'level' => (
   is          => 'rw',
-  isa         => 'HealthLevel',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Enum[qw(cluster indices shards awareness_attributes)],
 );
 
 has 'awareness_attributes' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'local' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'wait_for_active_shards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'wait_for_nodes' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'wait_for_events' => (
   is          => 'rw',
-  isa         => 'HealthWaitForEvents',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Enum[qw(immediate urgent high normal low languid)],
 );
 
 has 'wait_for_no_relocating_shards' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'wait_for_no_initializing_shards' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'wait_for_status' => (
   is          => 'rw',
-  isa         => 'HealthWaitForStatus',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Enum[qw(green yellow red)],
 );
 
 has 'weights' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 around [
@@ -175,5 +91,66 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    level => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    awareness_attributes => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    local => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    wait_for_active_shards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    wait_for_nodes => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    wait_for_events => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    wait_for_no_relocating_shards => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    wait_for_no_initializing_shards => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    wait_for_status => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    weights => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Cluster/SetDecommissionAwareness.pm
+++ b/lib/OpenSearch/Parameters/Cluster/SetDecommissionAwareness.pm
@@ -1,27 +1,22 @@
 package OpenSearch::Parameters::Cluster::SetDecommissionAwareness;
-use Moose::Role;
-use Moose::Util::TypeConstraints;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'attribute' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'value' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 around [qw/attribute value/] => sub {
@@ -34,5 +29,18 @@ around [qw/attribute value/] => sub {
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    attribute => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    value => {
+      encode_func => 'as_is',
+      type        => 'path',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Cluster/SetRoutingAwareness.pm
+++ b/lib/OpenSearch/Parameters/Cluster/SetRoutingAwareness.pm
@@ -1,38 +1,25 @@
 package OpenSearch::Parameters::Cluster::SetRoutingAwareness;
-use Moose::Role;
-use Moose::Util::TypeConstraints;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str HashRef);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'attribute' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has '_version' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'weights' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 around [qw/attribute weights _version/] => sub {
@@ -45,5 +32,22 @@ around [qw/attribute weights _version/] => sub {
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    attribute => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    _version => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    weights => {
+      encode_func => 'as_is',
+      type        => 'body',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Cluster/Stats.pm
+++ b/lib/OpenSearch/Parameters/Cluster/Stats.pm
@@ -1,16 +1,17 @@
 package OpenSearch::Parameters::Cluster::Stats;
-use Moose::Role;
-use OpenSearch::Filter::Nodes;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'nodes' => (
   is          => 'rw',
-  isa         => 'OpenSearch::Filter::Nodes | Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  # TODO
+  #isa         => 'OpenSearch::Filter::Nodes | Str',
+  isa         => Str
 );
 
 around [qw/nodes/] => sub {
@@ -23,5 +24,14 @@ around [qw/nodes/] => sub {
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    nodes => {
+      encode_func => 'as_is',
+      type        => 'path',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Cluster/Stats.pm
+++ b/lib/OpenSearch/Parameters/Cluster/Stats.pm
@@ -9,8 +9,8 @@ with 'OpenSearch::Parameters';
 
 has 'nodes' => (
   is          => 'rw',
-  # TODO
-  #isa         => 'OpenSearch::Filter::Nodes | Str',
+  # TODO: may work if encode_func is applied to path arguments
+  #isa         => InstanceOf['OpenSearch::Filter::Nodes'] | Str,
   isa         => Str
 );
 

--- a/lib/OpenSearch/Parameters/Cluster/UpdateSettings.pm
+++ b/lib/OpenSearch/Parameters/Cluster/UpdateSettings.pm
@@ -1,62 +1,39 @@
 package OpenSearch::Parameters::Cluster::UpdateSettings;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str HashRef Bool);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'flat_settings' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'persistent' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 1,
-    forced_body => 0
-  }
+  isa         => HashRef,
+  required    => 1,
 );
 
 has 'transient' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 1,
-    forced_body => 0
-  }
+  isa         => HashRef,
+  required    => 1,
 );
+
 around [qw/flat_settings cluster_manager_timeout timeout persistent transient/] => sub {
   my $orig = shift;
   my $self = shift;
@@ -67,5 +44,32 @@ around [qw/flat_settings cluster_manager_timeout timeout persistent transient/] 
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    flat_settings => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    persistent => {
+      encode_func => 'as_is',
+      type        => 'body',
+      forced_body => 0
+    },
+    transient => {
+      encode_func => 'as_is',
+      type        => 'body',
+      forced_body => 0
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Document/Bulk.pm
+++ b/lib/OpenSearch/Parameters/Document/Bulk.pm
@@ -1,97 +1,51 @@
 package OpenSearch::Parameters::Document::Bulk;
-use Moose::Role;
-use Moose::Util::TypeConstraints;
-enum 'DocumentOpType'      => [qw(index create)];
-enum 'DocumentRefresh'     => [qw(true false wait_for)];
-enum 'DocumentVersionType' => [qw(internal external external_gte)];
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str ArrayRef Bool Enum);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has '_body' => (
   is          => 'rw',
-  isa         => 'ArrayRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bulk',
-    type        => 'body',
-    required    => 1,
-    forced_body => 1,
-  }
+  isa         => ArrayRef,
+  required    => 1,
 );
 
 has 'pipeline' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'refresh' => (
   is          => 'rw',
-  isa         => 'DocumentRefresh',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Enum[qw(true false wait_for)],
 );
 
 has 'require_alias' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'routing' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'wait_for_active_shards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [
@@ -108,5 +62,43 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    _body => {
+      encode_func => 'encode_bulk',
+      type        => 'body',
+      forced_body => 1,
+    },
+    pipeline => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    refresh => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    require_alias => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    routing => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    wait_for_active_shards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Document/Get.pm
+++ b/lib/OpenSearch/Parameters/Document/Get.pm
@@ -16,7 +16,8 @@ has 'index' => (
 
 has 'id' => (
   is          => 'rw',
-  isa         => Str,
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'preference' => (

--- a/lib/OpenSearch/Parameters/Document/Get.pm
+++ b/lib/OpenSearch/Parameters/Document/Get.pm
@@ -1,140 +1,72 @@
 package OpenSearch::Parameters::Document::Get;
-use Moose::Role;
-use Moose::Util::TypeConstraints;
-enum 'DocumentOpType'      => [qw(index create)];
-enum 'DocumentRefresh'     => [qw(true false wait_for)];
-enum 'DocumentVersionType' => [qw(internal external external_gte)];
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int Enum);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'id' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'preference' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'realtime' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'refresh' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'routing' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'stored_fields' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has '_source' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has '_source_includes' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has '_source_excludes' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'version' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'version_type' => (
   is          => 'rw',
-  isa         => 'DocumentVersionType',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Enum[qw(internal external external_gte)],
 );
 
 around [
@@ -151,5 +83,58 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    id => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    preference => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    realtime => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    refresh => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    routing => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    stored_fields => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    _source => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    _source_includes => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    _source_excludes => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    version => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    version_type => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Document/Index.pm
+++ b/lib/OpenSearch/Parameters/Document/Index.pm
@@ -1,174 +1,89 @@
 package OpenSearch::Parameters::Document::Index;
-use Moose::Role;
-use Moose::Util::TypeConstraints;
-enum 'DocumentOpType'      => [qw(index create)];
-enum 'DocumentRefresh'     => [qw(true false wait_for)];
-enum 'DocumentVersionType' => [qw(internal external external_gte)];
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int Enum HashRef);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 # create if _doc does not exist
 has 'create' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'id' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'doc' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 1,
-  }
+  isa         => HashRef,
+  required    => 1,
 );
 
 has 'if_seq_no' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'if_primary_term' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'op_type' => (
   is          => 'rw',
-  isa         => 'DocumentOpType',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Enum[qw(index create)],
 );
 
 has 'pipeline' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'routing' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'refresh' => (
   is          => 'rw',
-  isa         => 'DocumentRefresh',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Enum[qw(true false wait_for)],
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'version' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'version_type' => (
   is          => 'rw',
-  isa         => 'DocumentVersionType',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Enum[qw(internal external external_gte)],
 );
 
 has 'wait_for_active_shards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'require_alias' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 around [
@@ -186,5 +101,70 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    create => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    id => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    doc => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    if_seq_no => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    if_primary_term => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    op_type => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    pipeline => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    routing => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    refresh => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    version => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    version_type => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    wait_for_active_shards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    require_alias => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/ClearCache.pm
+++ b/lib/OpenSearch/Parameters/Index/ClearCache.pm
@@ -1,114 +1,55 @@
 package OpenSearch::Parameters::Index::ClearCache;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'fielddata' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'fields' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'file' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
-);
-
-has 'file' => (
-  is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'query' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'request' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 around [qw/index allow_no_indices expand_wildcards fielddata fields file ignore_unavailable query request/] => sub {
@@ -121,5 +62,46 @@ around [qw/index allow_no_indices expand_wildcards fielddata fields file ignore_
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',  
+    },
+    fielddata => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    fields => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    file => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    query => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    request => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Clone.pm
+++ b/lib/OpenSearch/Parameters/Index/Clone.pm
@@ -1,103 +1,58 @@
 package OpenSearch::Parameters::Index::Clone;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool HashRef);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'target' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'settings' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 has 'aliases' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 has 'wait_for_active_shards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'wait_for_completion' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'task_execution_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [
@@ -112,5 +67,46 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    target => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    settings => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    aliases => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    wait_for_active_shards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    wait_for_completion => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    task_execution_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Close.pm
+++ b/lib/OpenSearch/Parameters/Index/Close.pm
@@ -1,81 +1,47 @@
 package OpenSearch::Parameters::Index::Close;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'wait_for_active_shards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [
@@ -90,5 +56,38 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    wait_for_active_shards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Create.pm
+++ b/lib/OpenSearch/Parameters/Index/Create.pm
@@ -1,81 +1,47 @@
 package OpenSearch::Parameters::Index::Create;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str HashRef);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'settings' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 has 'mappings' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 has 'aliases' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 has 'wait_for_active_shards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/index settings mappings aliases wait_for_active_shards cluster_manager_timeout timeout/] => sub {
@@ -88,5 +54,38 @@ around [qw/index settings mappings aliases wait_for_active_shards cluster_manage
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    settings => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    mappings => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    aliases => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    wait_for_active_shards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Delete.pm
+++ b/lib/OpenSearch/Parameters/Index/Delete.pm
@@ -1,70 +1,42 @@
 package OpenSearch::Parameters::Index::Delete;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/index allow_no_indices expand_wildcards ignore_unavailable cluster_manager_timeout timeout/] => sub {
@@ -77,5 +49,34 @@ around [qw/index allow_no_indices expand_wildcards ignore_unavailable cluster_ma
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/DeleteDangling.pm
+++ b/lib/OpenSearch/Parameters/Index/DeleteDangling.pm
@@ -1,48 +1,32 @@
 package OpenSearch::Parameters::Index::DeleteDangling;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index_uuid' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'accept_data_loss' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/index_uuid accept_data_loss timeout cluster_manager_timeout/] => sub {
@@ -55,5 +39,26 @@ around [qw/index_uuid accept_data_loss timeout cluster_manager_timeout/] => sub 
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index_uuid => {
+      encode_func => 'as_is',
+      type        => 'path', 
+    },
+    accept_data_loss => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Exists.pm
+++ b/lib/OpenSearch/Parameters/Index/Exists.pm
@@ -1,81 +1,47 @@
 package OpenSearch::Parameters::Index::Exists;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'flat_settings' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'include_defaults' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'local' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 around [qw/index allow_no_indices expand_wildcards flat_settings include_defaults ignore_unavailable local/] => sub {
@@ -88,5 +54,38 @@ around [qw/index allow_no_indices expand_wildcards flat_settings include_default
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    flat_settings => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    include_defaults => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    local => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/ForceMerge.pm
+++ b/lib/OpenSearch/Parameters/Index/ForceMerge.pm
@@ -83,7 +83,7 @@ sub api_spec {
       type        => 'url',
     },
     max_num_segments => {
-      encode_func => 'encode_bool',
+      encode_func => 'as_is',
       type        => 'url',
     },
     only_expunge_deletes => {

--- a/lib/OpenSearch/Parameters/Index/ForceMerge.pm
+++ b/lib/OpenSearch/Parameters/Index/ForceMerge.pm
@@ -1,92 +1,50 @@
 package OpenSearch::Parameters::Index::ForceMerge;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'flush' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'max_num_segments' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'only_expunge_deletes' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'primary_only' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 around [
@@ -101,5 +59,42 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    flush => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    max_num_segments => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    only_expunge_deletes => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    primary_only => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Get.pm
+++ b/lib/OpenSearch/Parameters/Index/Get.pm
@@ -1,92 +1,52 @@
 package OpenSearch::Parameters::Index::Get;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'flat_settings' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'include_defaults' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'local' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [
@@ -101,5 +61,42 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path', 
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    flat_settings => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    include_defaults => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    local => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/GetDangling.pm
+++ b/lib/OpenSearch/Parameters/Index/GetDangling.pm
@@ -1,48 +1,30 @@
 package OpenSearch::Parameters::Index::GetDangling;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index_uuid' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'accept_data_loss' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/index_uuid accept_data_loss timeout cluster_manager_timeout/] => sub {
@@ -55,5 +37,26 @@ around [qw/index_uuid accept_data_loss timeout cluster_manager_timeout/] => sub 
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index_uuid => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    accept_data_loss => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/GetMappings.pm
+++ b/lib/OpenSearch/Parameters/Index/GetMappings.pm
@@ -1,26 +1,22 @@
 package OpenSearch::Parameters::Index::GetMappings;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'field' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/index field/] => sub {
@@ -33,5 +29,18 @@ around [qw/index field/] => sub {
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    field => {
+      encode_func => 'as_is',
+      type        => 'path',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/GetSettings.pm
+++ b/lib/OpenSearch/Parameters/Index/GetSettings.pm
@@ -1,103 +1,55 @@
 package OpenSearch::Parameters::Index::GetSettings;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'setting' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'flat_settings' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'include_defaults' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'local' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [
@@ -112,5 +64,46 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    setting => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    flat_settings => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    include_defaults => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    local => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/ImportDangling.pm
+++ b/lib/OpenSearch/Parameters/Index/ImportDangling.pm
@@ -1,48 +1,32 @@
 package OpenSearch::Parameters::Index::ImportDangling;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index_uuid' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'accept_data_loss' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/index_uuid accept_data_loss timeout cluster_manager_timeout/] => sub {
@@ -55,5 +39,26 @@ around [qw/index_uuid accept_data_loss timeout cluster_manager_timeout/] => sub 
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index_uuid => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    accept_data_loss => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Open.pm
+++ b/lib/OpenSearch/Parameters/Index/Open.pm
@@ -1,103 +1,57 @@
 package OpenSearch::Parameters::Index::Open;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'wait_for_active_shards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'wait_for_completion' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'task_execution_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [
@@ -112,5 +66,46 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    wait_for_active_shards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    wait_for_completion => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    task_execution_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Refresh.pm
+++ b/lib/OpenSearch/Parameters/Index/Refresh.pm
@@ -1,48 +1,30 @@
 package OpenSearch::Parameters::Index::Refresh;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/index ignore_unavailable allow_no_indices expand_wildcards/] => sub {
@@ -55,5 +37,26 @@ around [qw/index ignore_unavailable allow_no_indices expand_wildcards/] => sub {
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/SetAliases.pm
+++ b/lib/OpenSearch/Parameters/Index/SetAliases.pm
@@ -1,37 +1,25 @@
 package OpenSearch::Parameters::Index::SetAliases;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str ArrayRef);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'actions' => (
   is          => 'rw',
-  isa         => 'ArrayRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => ArrayRef,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/actions cluster_manager_timeout timeout/] => sub {
@@ -44,5 +32,22 @@ around [qw/actions cluster_manager_timeout timeout/] => sub {
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    actions => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/SetMappings.pm
+++ b/lib/OpenSearch/Parameters/Index/SetMappings.pm
@@ -1,114 +1,63 @@
 package OpenSearch::Parameters::Index::SetMappings;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool HashRef);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'properties' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 1,
-  }
+  isa         => HashRef,
+  required    => 1,
 );
 
 has 'dynamic' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'ignore_malformed' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'write_index_only' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 around [
@@ -123,5 +72,50 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    properties => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    dynamic => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    ignore_malformed => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    write_index_only => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Shrink.pm
+++ b/lib/OpenSearch/Parameters/Index/Shrink.pm
@@ -1,81 +1,48 @@
 package OpenSearch::Parameters::Index::Shrink;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'target' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'wait_for_active_shards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'wait_for_completion' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'task_execution_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [
@@ -90,5 +57,38 @@ around [
   }
   return ( $self->$orig );
   };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    target => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    wait_for_active_shards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    wait_for_completion => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    task_execution_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Split.pm
+++ b/lib/OpenSearch/Parameters/Index/Split.pm
@@ -1,103 +1,58 @@
 package OpenSearch::Parameters::Index::Split;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool HashRef);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'target' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'wait_for_active_shards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'wait_for_completion' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'task_execution_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'settings' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 has 'aliases' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 around [
@@ -112,5 +67,46 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path', 
+    },
+    target => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    wait_for_active_shards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    wait_for_completion => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    task_execution_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    settings => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    aliases => {
+      encode_func => 'as_is',
+      type        => 'body',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Stats.pm
+++ b/lib/OpenSearch/Parameters/Index/Stats.pm
@@ -1,121 +1,67 @@
 package OpenSearch::Parameters::Index::Stats;
-use Moose::Role;
-use Moose::Util::TypeConstraints;
-enum 'StatsMetrics' => [
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool HashRef Enum);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
+
+my $StatsMetrics = Enum[
   qw(_all completion docs fielddata flush get indexing merge query_cache refresh refresh_cache search segments store translog warmer)
 ];
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'metric' => (
   is  => 'rw',
-  isa => 'Str',
-
+  isa => Str,
+  # TODO
   #isa         => 'ArrayRef[StatsMetrics]|Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'concat_comma',
-    type        => 'path',
-    required    => 0,
-  },
   reader => 'get_metrics',
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str
 );
 
 has 'fields' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'completions_fields' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'fielddata_fields' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'forbid_closed_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'groups' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'level' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'include_segment_file_sizes' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 # TODO: Handle ARRAYREF getter for path parameters. i.e.: metrics
@@ -132,5 +78,50 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    metric => {
+      encode_func => 'concat_comma',
+      type        => 'path',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    fields => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    completions_fields => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    fielddata_fields => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    forbid_closed_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    groups => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    level => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    include_segment_file_sizes => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Index/Stats.pm
+++ b/lib/OpenSearch/Parameters/Index/Stats.pm
@@ -2,7 +2,8 @@ package OpenSearch::Parameters::Index::Stats;
 use strict;
 use warnings;
 use feature qw(state);
-use Types::Standard qw(Str Bool HashRef Enum);
+use Types::Standard qw(Str Bool ArrayRef Enum);
+use Types::Common::String qw(NonEmptyStr);
 use Moo::Role;
 
 with 'OpenSearch::Parameters';
@@ -18,10 +19,9 @@ has 'index' => (
 
 has 'metric' => (
   is  => 'rw',
-  isa => Str,
-  # TODO
-  #isa         => 'ArrayRef[StatsMetrics]|Str',
-  reader => 'get_metrics',
+  # TODO: type checks works, but encode_func is not applied for path arguments
+  #isa => ArrayRef[$StatsMetrics] | Str,
+  isa => NonEmptyStr,
 );
 
 has 'expand_wildcards' => (
@@ -86,7 +86,7 @@ sub api_spec {
       type        => 'path',
     },
     metric => {
-      encode_func => 'concat_comma',
+      encode_func => 'as_is',
       type        => 'path',
     },
     expand_wildcards => {

--- a/lib/OpenSearch/Parameters/Index/UpdateSettings.pm
+++ b/lib/OpenSearch/Parameters/Index/UpdateSettings.pm
@@ -1,82 +1,47 @@
 package OpenSearch::Parameters::Index::UpdateSettings;
-use Moose::Role;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool HashRef);
+use Types::Common::String qw(NonEmptyStr);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 1,
-  }
+  isa         => NonEmptyStr,
+  required    => 1,
 );
 
 has 'settings' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-    forced_body => 1,
-  }
+  isa         => HashRef,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cluster_manager_timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'preserve_existing' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 around [qw/index settings allow_no_indices expand_wildcards cluster_manager_timeout preserve_existing timeout/] => sub {
@@ -89,5 +54,39 @@ around [qw/index settings allow_no_indices expand_wildcards cluster_manager_time
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    settings => {
+      encode_func => 'as_is',
+      type        => 'body',
+      forced_body => 1,
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cluster_manager_timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    preserve_existing => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'url',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Search/Count.pm
+++ b/lib/OpenSearch/Parameters/Search/Count.pm
@@ -1,159 +1,80 @@
 package OpenSearch::Parameters::Search::Count;
-use Moose::Role;
-use OpenSearch::Filter::Source;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int HashRef);
+use Moo::Role;
+
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'analyzer' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'analyze_wildcard' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'default_operator' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'df' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'lenient' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'min_score' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'routing' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'preference' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'terminate_after' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'query' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 around [
@@ -172,5 +93,66 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    analyzer => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    analyze_wildcard => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    default_operator => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    df => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    lenient => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    min_score => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    routing => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    preference => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    terminate_after => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    query => {
+      encode_func => 'as_is',
+      type        => 'body',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Search/Search.pm
+++ b/lib/OpenSearch/Parameters/Search/Search.pm
@@ -1,582 +1,278 @@
 package OpenSearch::Parameters::Search::Search;
-use Moose::Role;
-use OpenSearch::Filter::Source;
+use strict;
+use warnings;
+use feature qw(state);
+use Types::Standard qw(Str Bool Int ArrayRef HashRef);
+use Moo::Role;
+#use OpenSearch::Filter::Source;
 
-#use Moose::Util::TypeConstraints;
-
-#enum 'HealthWaitForStatus'   => [qw/green yellow red/];
+with 'OpenSearch::Parameters';
 
 has 'index' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'path',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'sort' => (
   is          => 'rw',
-  isa         => 'ArrayRef[HashRef]',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => ArrayRef[HashRef],
 );
 
 has 'version' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'timeout' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'terminate_after' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'stats' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has '_source' => (
   is          => 'rw',
-  isa         => 'OpenSearch::Filter::Source | Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
+  # TODO
+  #isa         => 'OpenSearch::Filter::Source | Str',
+  isa         => Str,
   description => {
     encode_func => 'as_is',
     type        => 'body',
-    required    => 0,
   }
 );
 
 has 'size' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'seq_no_primary_term' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'query' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 has 'min_score' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'indices_boost' => (
   is          => 'rw',
-  isa         => 'ArrayRef[HashRef]',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => ArrayRef[HashRef],
 );
 
 has 'from' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'explain' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'fields' => (
   is          => 'rw',
-  isa         => 'ArrayRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => ArrayRef,
 );
 
 has 'docvalue_fields' => (
   is          => 'rw',
-  isa         => 'ArrayRef[HashRef]',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => ArrayRef[HashRef],
 );
 
 has 'aggs' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 has 'search_after' => (
   is          => 'rw',
-  isa         => 'ArrayRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => ArrayRef,
 );
 
 has 'scroll_id' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'max_concurrent_shard_requests' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'stored_fields' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'ignore_throttled' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'allow_no_indices' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'q' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'request_cache' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'analyze_wildcard' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'suggest_text' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'rest_total_hits_as_int' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'routing' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 # See https://github.com/localh0rst/OpenSearch-Perl/issues/8
 has 'track_total_hits' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'cancel_after_time_interval' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has '_source_includes' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'pre_filter_shard_size' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'suggest_field' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'preference' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'suggest_size' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'default_operator' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'suggest_mode' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'allow_partial_search_results' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'search_type' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'expand_wildcards' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'typed_keys' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'ignore_unavailable' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'df' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'batched_reduce_size' => (
   is          => 'rw',
-  isa         => 'Int',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Int,
 );
 
 has 'analyzer' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has '_source_excludes' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'track_scores' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'lenient' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'ccs_minimize_roundtrips' => (
   is          => 'rw',
-  isa         => 'Bool',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'encode_bool',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Bool,
 );
 
 has 'scroll' => (
   is          => 'rw',
-  isa         => 'Str',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'url',
-    required    => 0,
-  }
+  isa         => Str,
 );
 
 has 'highlight' => (
   is          => 'rw',
-  isa         => 'HashRef',
-  metaclass   => 'MooseX::MetaDescription::Meta::Attribute',
-  description => {
-    encode_func => 'as_is',
-    type        => 'body',
-    required    => 0,
-  }
+  isa         => HashRef,
 );
 
 around [
@@ -600,5 +296,218 @@ around [
   }
   return ( $self->$orig );
 };
+
+sub api_spec {
+  state $s = +{
+    index => {
+      encode_func => 'as_is',
+      type        => 'path',
+    },
+    sort => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    version => {
+      encode_func => 'encode_bool',
+      type        => 'body',
+    },
+    timeout => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    terminate_after => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    stats => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    _source => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    size => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    seq_no_primary_term => {
+      encode_func => 'encode_bool',
+      type        => 'body',
+    },
+    query => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    min_score => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    indices_boost => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    from => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    explain => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    fields => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    docvalue_fields => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    aggs => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    search_after => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    scroll_id => {
+      encode_func => 'as_is',
+      type        => 'body',
+    },
+    max_concurrent_shard_requests => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    stored_fields => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    ignore_throttled => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    allow_no_indices => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    q => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    request_cache => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    analyze_wildcard => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    suggest_text => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    rest_total_hits_as_int => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    routing => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    track_total_hits => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    cancel_after_time_interval => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    _source_includes => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    pre_filter_shard_size => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    suggest_field => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    preference => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    suggest_size => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    default_operator => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    suggest_mode => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    allow_partial_search_results => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    search_type => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    expand_wildcards => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    typed_keys => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    ignore_unavailable => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    df => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    batched_reduce_size => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    analyzer => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    _source_excludes => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    track_scores => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    lenient => {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    ccs_minimize_roundtrips {
+      encode_func => 'encode_bool',
+      type        => 'url',
+    },
+    scroll => {
+      encode_func => 'as_is',
+      type        => 'url',
+    },
+    highlight => {
+      encode_func => 'as_is',
+      type        => 'body',
+    }
+  };
+}
 
 1;

--- a/lib/OpenSearch/Parameters/Search/Search.pm
+++ b/lib/OpenSearch/Parameters/Search/Search.pm
@@ -495,7 +495,7 @@ sub api_spec {
       encode_func => 'encode_bool',
       type        => 'url',
     },
-    ccs_minimize_roundtrips {
+    ccs_minimize_roundtrips => {
       encode_func => 'encode_bool',
       type        => 'url',
     },

--- a/lib/OpenSearch/Remote.pm
+++ b/lib/OpenSearch/Remote.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Remote;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use Data::Dumper;
 use OpenSearch::Remote::Info;
 use feature qw(signatures);
@@ -9,7 +10,7 @@ no warnings qw(experimental::signatures);
 
 has '_base' => (
   is  => 'rw',
-  isa => 'OpenSearch::Base',
+  isa => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,4 @@ sub info( $self, @params ) {
   return ( OpenSearch::Remote::Info->new(@params, _base => $self->_base)->execute );
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/OpenSearch/Remote/Info.pm
+++ b/lib/OpenSearch/Remote/Info.pm
@@ -1,13 +1,14 @@
 package OpenSearch::Remote::Info;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -15,5 +16,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ '_remote', 'info' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Response.pm
+++ b/lib/OpenSearch/Response.pm
@@ -1,15 +1,16 @@
 package OpenSearch::Response;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(Str Bool Int);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
 has '_response' => ( is => 'rw', required => 1 );
-has 'success'   => ( is => 'rw', isa      => 'Bool', required => 0 );
-has 'message'   => ( is => 'rw', isa      => 'Str',  required => 0 );
+has 'success'   => ( is => 'rw', isa      => Bool, required => 0 );
+has 'message'   => ( is => 'rw', isa      => Str,  required => 0 );
 has 'error'     => ( is => 'rw', required => 0 );
-has 'code'      => ( is => 'rw', isa      => 'Int', required => 0 );
+has 'code'      => ( is => 'rw', isa      => Int, required => 0 );
 has 'data'      => ( is => 'rw', required => 0 );
 
 sub BUILD( $self, @rest ) {
@@ -25,5 +26,4 @@ sub BUILD( $self, @rest ) {
 
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/OpenSearch/Search.pm
+++ b/lib/OpenSearch/Search.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Search;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use Data::Dumper;
 use OpenSearch::Search::Search;
 use OpenSearch::Search::Count;
@@ -10,7 +11,7 @@ no warnings qw(experimental::signatures);
 
 has '_base' => (
   is  => 'rw',
-  isa => 'OpenSearch::Base',
+  isa => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -22,5 +23,4 @@ sub count( $self, @params ) {
   return ( OpenSearch::Search::Count->new(@params, _base => $self->_base)->execute );
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/OpenSearch/Search/Count.pm
+++ b/lib/OpenSearch/Search/Count.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Search::Count;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Search::Count';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ ( $self->index // () ),, '_count' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/lib/OpenSearch/Search/Search.pm
+++ b/lib/OpenSearch/Search/Search.pm
@@ -1,7 +1,8 @@
 package OpenSearch::Search::Search;
 use strict;
 use warnings;
-use Moose;
+use Moo;
+use Types::Standard qw(InstanceOf);
 use feature qw(signatures);
 no warnings qw(experimental::signatures);
 
@@ -9,7 +10,7 @@ with 'OpenSearch::Parameters::Search::Search';
 
 has '_base' => (
   is       => 'rw',
-  isa      => 'OpenSearch::Base',
+  isa      => InstanceOf['OpenSearch::Base'],
   required => 1,
 );
 
@@ -17,5 +18,5 @@ sub execute($self) {
   my $res = $self->_base->_get( $self, [ ( $self->index // () ),, '_search' ] );
 }
 
-__PACKAGE__->meta->make_immutable;
+
 1;

--- a/t/01_opensearch_modules.t
+++ b/t/01_opensearch_modules.t
@@ -3,7 +3,7 @@ use Test::More 0.98;
 use Data::Dumper;
 
 plan skip_all => 'To test Modules, set OS_HOST, OS_USER, OS_PASS, OS_INDEX in ENV'
-  unless $ENV{OS_HOST} && $ENV{OS_USER} && $ENV{OS_PASS} && $ENV{OS_INDEX};
+  unless $ENV{OS_HOST} && exists($ENV{OS_USER}) && exists($ENV{OS_PASS}) && $ENV{OS_INDEX};
 
 my $host  = $ENV{OS_HOST};
 my $user  = $ENV{OS_USER};
@@ -18,7 +18,7 @@ my $os = OpenSearch->new(
   user            => $user,
   pass            => $pass,
   hosts           => [$host],
-  secure          => 1,
+  secure          => 0,
   allow_insecure  => 1,
   async           => 0,
   pool_count      => 10,
@@ -44,7 +44,7 @@ isa_ok $remote_api,  'OpenSearch::Remote',   'Remote object created';
 isa_ok $cluster_api->health, 'OpenSearch::Response', 'Sync returns OpenSearch::Response object';
 
 # Switch to async
-$os->base->async(1);
+$os->_base->async(1);
 my $promise = $cluster_api->health;
 
 isa_ok $promise, 'Mojo::Promise', 'Async returns Mojo::Promise object';

--- a/t/02_index.t
+++ b/t/02_index.t
@@ -3,7 +3,7 @@ use Test::More 0.98;
 use Data::Dumper;
 
 plan skip_all => 'To test Modules, set OS_HOST, OS_USER, OS_PASS, OS_INDEX in ENV'
-  unless $ENV{OS_HOST} && $ENV{OS_USER} && $ENV{OS_PASS} && $ENV{OS_INDEX};
+  unless $ENV{OS_HOST} && exists($ENV{OS_USER}) && exists($ENV{OS_PASS}) && $ENV{OS_INDEX};
 
 my $host  = $ENV{OS_HOST};
 my $user  = $ENV{OS_USER};
@@ -18,7 +18,7 @@ my $os = OpenSearch->new(
   user            => $user,
   pass            => $pass,
   hosts           => [$host],
-  secure          => 1,
+  secure          => 0,
   allow_insecure  => 1,
   async           => 0,
   pool_count      => 10,


### PR DESCRIPTION
Done:

* migrated from `Moose` to `Moo` with type checking by `Type::Tiny`
* moved parameter requirement (Moo attribute `required`) to Moo, as Moo already applies type checking (via attribute `isa`). This way we can let the specification focus on the encoding.
* fixed some minor routes (see individual commits)
* disabled some unused packages (e.g. `OpenSearch::Filter::Nodes` that was not really used, and whose encoding could not be applied, as every path parameter is never encoded).
* I have split parameter validation from specification for now. So generation of `has` statements based on a single specification list. As the list of parameter may become long, this will probably make updating the package difficult, but I did it to simplify the helper method that does not have to distinguish between variables to be ignored and those to process. With the exception of the path parameters  of course ..